### PR TITLE
Relax generator-core-version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Getting started Adobe Generator",
   "main": "main.js",
-  "generator-core-version": "~2",
+  "generator-core-version": "1 - 3.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tomkrcha/generator-getting-started"


### PR DESCRIPTION
Updates the plugin to allow compatibility with any Generator core version between 1 and 3.1. (Generator core master is currently at 3.1-dev and PS15 is shipping with 3.0.0.)
